### PR TITLE
Triggers

### DIFF
--- a/GlobalBlueprint.cs
+++ b/GlobalBlueprint.cs
@@ -75,4 +75,25 @@ namespace NGUIndustriesInjector
         public BuildingType BuildingType { get; set; }
         public TileDirection TileDirection { get; set; }
     }
+
+    public class GlobalBlueprintTrigger
+    {
+        public GlobalBlueprintTrigger()
+        {
+
+        }
+
+        public GlobalBlueprintTrigger(string blueprintName, int? materialCount, BuildingType buildingType)
+        {
+            BlueprintName = blueprintName;
+            MaterialCount = materialCount;
+            BuildingType = buildingType;
+        }
+
+        public string BlueprintName { get; set; }
+
+        public int? MaterialCount { get; set; }
+
+        public BuildingType BuildingType { get; set; }
+    }
 }

--- a/Main.cs
+++ b/Main.cs
@@ -332,6 +332,10 @@ namespace NGUIndustriesInjector
         {
             if (!Settings.GlobalEnabled)
                 return;
+
+            var player = FindObjectOfType<Player>();
+
+            ManageGlobalBlueprintTriggers(player);
         }
 
         // Runs every MAIN_DELAY seconds, our main loop
@@ -628,6 +632,16 @@ namespace NGUIndustriesInjector
                         SetOne(player, newBuilding);
                     }
                 }
+            }
+        }
+
+        private void ManageGlobalBlueprintTriggers(Player player)
+        {
+            // Debug("Successful trigger of ManageGlobalBlueprintTriggers", "Main");
+
+            if (Settings.GlobalBlueprintTriggers?.Any() == true)
+            {
+                // Debug("Successful detected list of triggers", "Main");
             }
         }
 

--- a/Main.cs
+++ b/Main.cs
@@ -635,15 +635,8 @@ namespace NGUIndustriesInjector
             }
         }
 
-        private void ManageGlobalBlueprintTriggers(Player player)
-        {
-            // Debug("Successful trigger of ManageGlobalBlueprintTriggers", "Main");
-
-            if (Settings.GlobalBlueprintTriggers?.Any() == true)
-            {
-                // Debug("Successful detected list of triggers", "Main");
-            }
-        }
+        private void ManageGlobalBlueprintTriggers(Player player) =>
+            Settings.GlobalBlueprintTriggers?.FirstOrDefault()?.Trigger(player);
 
         private static void SetOne(Player player, MaterialState newBuilding)
         {

--- a/SavedSettings.cs
+++ b/SavedSettings.cs
@@ -14,8 +14,15 @@ namespace NGUIndustriesInjector
         [JsonProperty] private bool _factoryDontStarve = true;
         [JsonProperty] private bool _factoryBuildStandard = true;
         [JsonProperty] private List<PriorityMaterial> _priorytyBuildings = new List<PriorityMaterial>();
-        [JsonProperty] private List<GlobalBlueprint> _globalBlueprints = new List<GlobalBlueprint>() { new GlobalBlueprint("Default") };
-        [JsonProperty] private List<GlobalBlueprintTrigger> _globalBlueprintTriggers = new List<GlobalBlueprintTrigger>();
+        [JsonProperty] private List<GlobalBlueprint> _globalBlueprints = new List<GlobalBlueprint>() 
+        { 
+            new GlobalBlueprint("Default") 
+        };
+
+        [JsonProperty] private List<GlobalBlueprintTrigger> _globalBlueprintTriggers = new List<GlobalBlueprintTrigger>()
+        {
+            new GlobalBlueprintTrigger("Default", BuildingType.None, 0)
+        };
 
         [JsonProperty] private bool _manageFactories = false;
         [JsonProperty] private bool _manageWorkOrders = false;
@@ -74,6 +81,7 @@ namespace NGUIndustriesInjector
                 {
                     _priorytyBuildings.Clear();
                     _globalBlueprints.Clear();
+                    _globalBlueprintTriggers.Clear();
 
                     var json = File.ReadAllText(savePath);
                     JsonConvert.PopulateObject(json, this);
@@ -91,7 +99,7 @@ namespace NGUIndustriesInjector
             {
                 Main.Log("Creating new default Settings");
             }
-            //Main.Log(JsonUtility.ToJson(this, true));
+
             Main.Log(JsonConvert.SerializeObject(this, Formatting.Indented));
         }
 
@@ -144,6 +152,11 @@ namespace NGUIndustriesInjector
             set
             {
                 _globalBlueprints = value;
+                if (_globalBlueprints.Count == 0)
+                {
+                    _globalBlueprints.Add(new GlobalBlueprint("Default"));
+                }
+
                 SaveSettings();
             }
         }
@@ -154,6 +167,11 @@ namespace NGUIndustriesInjector
             set
             {
                 _globalBlueprintTriggers = value;
+                if (_globalBlueprints.Count == 0)
+                {
+                    _globalBlueprintTriggers.Add(new GlobalBlueprintTrigger("Default", BuildingType.None, 0));
+                }
+
                 SaveSettings();
             }
         }

--- a/SavedSettings.cs
+++ b/SavedSettings.cs
@@ -14,7 +14,7 @@ namespace NGUIndustriesInjector
         [JsonProperty] private bool _factoryDontStarve = true;
         [JsonProperty] private bool _factoryBuildStandard = true;
         [JsonProperty] private List<PriorityMaterial> _priorytyBuildings = new List<PriorityMaterial>();
-        [JsonProperty] private List<GlobalBlueprint> _globalBlueprints = new List<GlobalBlueprint>();
+        [JsonProperty] private List<GlobalBlueprint> _globalBlueprints = new List<GlobalBlueprint>() { new GlobalBlueprint("Default") };
 
         [JsonProperty] private bool _manageFactories = false;
         [JsonProperty] private bool _manageWorkOrders = false;
@@ -76,12 +76,7 @@ namespace NGUIndustriesInjector
 
                     var json = File.ReadAllText(savePath);
                     JsonConvert.PopulateObject(json, this);
-
-                    if (!GlobalBlueprints.Any())
-                    {
-                        GlobalBlueprints.Add(new GlobalBlueprint("Default"));
-                    }
-
+                    
                     Main.Log("Loaded Settings");
                 }
                 catch (Exception e)

--- a/SavedSettings.cs
+++ b/SavedSettings.cs
@@ -15,6 +15,7 @@ namespace NGUIndustriesInjector
         [JsonProperty] private bool _factoryBuildStandard = true;
         [JsonProperty] private List<PriorityMaterial> _priorytyBuildings = new List<PriorityMaterial>();
         [JsonProperty] private List<GlobalBlueprint> _globalBlueprints = new List<GlobalBlueprint>() { new GlobalBlueprint("Default") };
+        [JsonProperty] private List<GlobalBlueprintTrigger> _globalBlueprintTriggers = new List<GlobalBlueprintTrigger>();
 
         [JsonProperty] private bool _manageFactories = false;
         [JsonProperty] private bool _manageWorkOrders = false;
@@ -143,6 +144,16 @@ namespace NGUIndustriesInjector
             set
             {
                 _globalBlueprints = value;
+                SaveSettings();
+            }
+        }
+
+        public List<GlobalBlueprintTrigger> GlobalBlueprintTriggers
+        {
+            get => _globalBlueprintTriggers;
+            set
+            {
+                _globalBlueprintTriggers = value;
                 SaveSettings();
             }
         }

--- a/SettingsForm.Designer.cs
+++ b/SettingsForm.Designer.cs
@@ -29,7 +29,9 @@
         /// </summary>
         private void InitializeComponent()
         {
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle12 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle10 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle11 = new System.Windows.Forms.DataGridViewCellStyle();
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.tabControl1 = new System.Windows.Forms.TabControl();
@@ -58,15 +60,17 @@
             this.FactoryBuildStandard = new System.Windows.Forms.CheckBox();
             this.FactoryDontStarve = new System.Windows.Forms.CheckBox();
             this.tabPage3 = new System.Windows.Forms.TabPage();
+            this.btnSaveTriggers = new System.Windows.Forms.Button();
+            this.label1 = new System.Windows.Forms.Label();
             this.GlobalBlueprintTriggersDataGridView = new System.Windows.Forms.DataGridView();
-            this.triggerBlueprintName = new System.Windows.Forms.DataGridViewComboBoxColumn();
-            this.triggerBuildingType = new System.Windows.Forms.DataGridViewComboBoxColumn();
-            this.triggerCount = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.label2 = new System.Windows.Forms.Label();
             this.GlobalBluePrintsDataView = new System.Windows.Forms.DataGridView();
             this.blueprintName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.blueprintSave = new System.Windows.Forms.DataGridViewButtonColumn();
             this.blueprintLoad = new System.Windows.Forms.DataGridViewButtonColumn();
+            this.TriggerListBlueprintColumnName = new System.Windows.Forms.DataGridViewComboBoxColumn();
+            this.TriggerBlueprintBuildingTypeColumn = new System.Windows.Forms.DataGridViewComboBoxColumn();
+            this.triggerCount = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.flowLayoutPanel1.SuspendLayout();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
@@ -332,7 +336,7 @@
             // FactoryPriorityMaterialsDataGridView
             // 
             this.FactoryPriorityMaterialsDataGridView.AccessibleRole = System.Windows.Forms.AccessibleRole.Alert;
-            this.FactoryPriorityMaterialsDataGridView.AllowUserToResizeRows = false;
+            this.FactoryPriorityMaterialsDataGridView.AllowUserToOrderColumns = true;
             this.FactoryPriorityMaterialsDataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.FactoryPriorityMaterialsDataGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.FactoriesPrioListColumnName,
@@ -358,9 +362,9 @@
             // FactoriesPrioListColumnWant
             // 
             this.FactoriesPrioListColumnWant.DataPropertyName = "Want";
-            dataGridViewCellStyle1.Format = "N0";
-            dataGridViewCellStyle1.NullValue = null;
-            this.FactoriesPrioListColumnWant.DefaultCellStyle = dataGridViewCellStyle1;
+            dataGridViewCellStyle12.Format = "N0";
+            dataGridViewCellStyle12.NullValue = null;
+            this.FactoriesPrioListColumnWant.DefaultCellStyle = dataGridViewCellStyle12;
             this.FactoriesPrioListColumnWant.HeaderText = "Number want";
             this.FactoriesPrioListColumnWant.MinimumWidth = 8;
             this.FactoriesPrioListColumnWant.Name = "FactoriesPrioListColumnWant";
@@ -416,6 +420,8 @@
             // 
             // tabPage3
             // 
+            this.tabPage3.Controls.Add(this.btnSaveTriggers);
+            this.tabPage3.Controls.Add(this.label1);
             this.tabPage3.Controls.Add(this.GlobalBlueprintTriggersDataGridView);
             this.tabPage3.Controls.Add(this.label2);
             this.tabPage3.Controls.Add(this.GlobalBluePrintsDataView);
@@ -426,44 +432,49 @@
             this.tabPage3.Text = "Global Blueprints";
             this.tabPage3.UseVisualStyleBackColor = true;
             // 
+            // btnSaveTriggers
+            // 
+            this.btnSaveTriggers.Location = new System.Drawing.Point(780, 473);
+            this.btnSaveTriggers.Name = "btnSaveTriggers";
+            this.btnSaveTriggers.Size = new System.Drawing.Size(93, 31);
+            this.btnSaveTriggers.TabIndex = 4;
+            this.btnSaveTriggers.Text = "Save";
+            this.btnSaveTriggers.UseVisualStyleBackColor = true;
+            this.btnSaveTriggers.Click += new System.EventHandler(this.btnSaveTriggers_Click);
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(17, 263);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(195, 20);
+            this.label1.TabIndex = 3;
+            this.label1.Text = "Swap to Blueprint Triggers";
+            // 
             // GlobalBlueprintTriggersDataGridView
             // 
+            this.GlobalBlueprintTriggersDataGridView.AllowUserToResizeColumns = false;
+            this.GlobalBlueprintTriggersDataGridView.AllowUserToResizeRows = false;
+            dataGridViewCellStyle10.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+            dataGridViewCellStyle10.BackColor = System.Drawing.SystemColors.Control;
+            dataGridViewCellStyle10.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            dataGridViewCellStyle10.ForeColor = System.Drawing.SystemColors.WindowText;
+            dataGridViewCellStyle10.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+            dataGridViewCellStyle10.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+            dataGridViewCellStyle10.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.GlobalBlueprintTriggersDataGridView.ColumnHeadersDefaultCellStyle = dataGridViewCellStyle10;
             this.GlobalBlueprintTriggersDataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.GlobalBlueprintTriggersDataGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
-            this.triggerBlueprintName,
-            this.triggerBuildingType,
+            this.TriggerListBlueprintColumnName,
+            this.TriggerBlueprintBuildingTypeColumn,
             this.triggerCount});
-            this.GlobalBlueprintTriggersDataGridView.Location = new System.Drawing.Point(17, 320);
+            this.GlobalBlueprintTriggersDataGridView.Location = new System.Drawing.Point(17, 289);
+            this.GlobalBlueprintTriggersDataGridView.MultiSelect = false;
             this.GlobalBlueprintTriggersDataGridView.Name = "GlobalBlueprintTriggersDataGridView";
             this.GlobalBlueprintTriggersDataGridView.RowHeadersWidth = 62;
             this.GlobalBlueprintTriggersDataGridView.RowTemplate.Height = 28;
             this.GlobalBlueprintTriggersDataGridView.Size = new System.Drawing.Size(857, 177);
             this.GlobalBlueprintTriggersDataGridView.TabIndex = 2;
-            this.GlobalBlueprintTriggersDataGridView.RowEnter += new System.Windows.Forms.DataGridViewCellEventHandler(this.GlobalBlueprintTriggersDataGridView_RowEnter);
-            this.GlobalBlueprintTriggersDataGridView.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.GlobalBlueprintTriggersDataGridView_RowsAdded);
-            // 
-            // triggerBlueprintName
-            // 
-            this.triggerBlueprintName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.triggerBlueprintName.HeaderText = "Blueprint Name";
-            this.triggerBlueprintName.MinimumWidth = 8;
-            this.triggerBlueprintName.Name = "triggerBlueprintName";
-            // 
-            // triggerBuildingType
-            // 
-            this.triggerBuildingType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.triggerBuildingType.DataPropertyName = "BuildingType";
-            this.triggerBuildingType.HeaderText = "Building Type";
-            this.triggerBuildingType.MinimumWidth = 8;
-            this.triggerBuildingType.Name = "triggerBuildingType";
-            // 
-            // triggerCount
-            // 
-            this.triggerCount.DataPropertyName = "MaterialCount";
-            this.triggerCount.HeaderText = "Count";
-            this.triggerCount.MinimumWidth = 8;
-            this.triggerCount.Name = "triggerCount";
-            this.triggerCount.Width = 150;
             // 
             // label2
             // 
@@ -481,14 +492,15 @@
             this.blueprintName,
             this.blueprintSave,
             this.blueprintLoad});
-            this.GlobalBluePrintsDataView.Location = new System.Drawing.Point(17, 45);
+            this.GlobalBluePrintsDataView.Location = new System.Drawing.Point(17, 34);
             this.GlobalBluePrintsDataView.Name = "GlobalBluePrintsDataView";
             this.GlobalBluePrintsDataView.RowHeadersWidth = 62;
             this.GlobalBluePrintsDataView.RowTemplate.Height = 28;
-            this.GlobalBluePrintsDataView.Size = new System.Drawing.Size(857, 246);
+            this.GlobalBluePrintsDataView.Size = new System.Drawing.Size(857, 201);
             this.GlobalBluePrintsDataView.TabIndex = 0;
             this.GlobalBluePrintsDataView.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.GlobalBluePrintsDataView_CellContentClick);
             this.GlobalBluePrintsDataView.RowValidating += new System.Windows.Forms.DataGridViewCellCancelEventHandler(this.GlobalBluePrintsDataView_RowValidating);
+            this.GlobalBluePrintsDataView.UserDeletedRow += new System.Windows.Forms.DataGridViewRowEventHandler(this.GlobalBluePrintsDataView_UserDeletedRow);
             // 
             // blueprintName
             // 
@@ -518,6 +530,35 @@
             this.blueprintLoad.Text = "Load";
             this.blueprintLoad.UseColumnTextForButtonValue = true;
             this.blueprintLoad.Width = 150;
+            // 
+            // TriggerListBlueprintColumnName
+            // 
+            this.TriggerListBlueprintColumnName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.TriggerListBlueprintColumnName.DataPropertyName = "BlueprintName";
+            dataGridViewCellStyle11.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
+            this.TriggerListBlueprintColumnName.DefaultCellStyle = dataGridViewCellStyle11;
+            this.TriggerListBlueprintColumnName.HeaderText = "Blueprint Name";
+            this.TriggerListBlueprintColumnName.MinimumWidth = 8;
+            this.TriggerListBlueprintColumnName.Name = "TriggerListBlueprintColumnName";
+            this.TriggerListBlueprintColumnName.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            // 
+            // TriggerBlueprintBuildingTypeColumn
+            // 
+            this.TriggerBlueprintBuildingTypeColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.TriggerBlueprintBuildingTypeColumn.DataPropertyName = "BuildingType";
+            this.TriggerBlueprintBuildingTypeColumn.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.TriggerBlueprintBuildingTypeColumn.HeaderText = "Building Type";
+            this.TriggerBlueprintBuildingTypeColumn.MinimumWidth = 8;
+            this.TriggerBlueprintBuildingTypeColumn.Name = "TriggerBlueprintBuildingTypeColumn";
+            this.TriggerBlueprintBuildingTypeColumn.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            // 
+            // triggerCount
+            // 
+            this.triggerCount.DataPropertyName = "MaterialCount";
+            this.triggerCount.HeaderText = "Count";
+            this.triggerCount.MinimumWidth = 8;
+            this.triggerCount.Name = "triggerCount";
+            this.triggerCount.Width = 264;
             // 
             // SettingsForm
             // 
@@ -579,8 +620,10 @@
         private System.Windows.Forms.DataGridViewComboBoxColumn FactoriesPrioListColumnName;
         private System.Windows.Forms.DataGridViewTextBoxColumn FactoriesPrioListColumnWant;
         private System.Windows.Forms.DataGridView GlobalBlueprintTriggersDataGridView;
-        private System.Windows.Forms.DataGridViewComboBoxColumn triggerBlueprintName;
-        private System.Windows.Forms.DataGridViewComboBoxColumn triggerBuildingType;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.Button btnSaveTriggers;
+        private System.Windows.Forms.DataGridViewComboBoxColumn TriggerListBlueprintColumnName;
+        private System.Windows.Forms.DataGridViewComboBoxColumn TriggerBlueprintBuildingTypeColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn triggerCount;
     }
 }

--- a/SettingsForm.Designer.cs
+++ b/SettingsForm.Designer.cs
@@ -51,25 +51,29 @@
             this.AutoDailySpin = new System.Windows.Forms.CheckBox();
             this.tabPage2 = new System.Windows.Forms.TabPage();
             this.FactoryPriorityMaterialsDataGridView = new System.Windows.Forms.DataGridView();
+            this.FactoriesPrioListColumnName = new System.Windows.Forms.DataGridViewComboBoxColumn();
+            this.FactoriesPrioListColumnWant = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.FactoryPriorityItemsLabelMain = new System.Windows.Forms.Label();
             this.FactoryPriorityItemsSaveButton = new System.Windows.Forms.Button();
             this.FactoryBuildStandard = new System.Windows.Forms.CheckBox();
             this.FactoryDontStarve = new System.Windows.Forms.CheckBox();
             this.tabPage3 = new System.Windows.Forms.TabPage();
-            this.button2 = new System.Windows.Forms.Button();
+            this.GlobalBlueprintTriggersDataGridView = new System.Windows.Forms.DataGridView();
+            this.triggerBlueprintName = new System.Windows.Forms.DataGridViewComboBoxColumn();
+            this.triggerBuildingType = new System.Windows.Forms.DataGridViewComboBoxColumn();
+            this.triggerCount = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.label2 = new System.Windows.Forms.Label();
             this.GlobalBluePrintsDataView = new System.Windows.Forms.DataGridView();
             this.blueprintName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.blueprintSave = new System.Windows.Forms.DataGridViewButtonColumn();
             this.blueprintLoad = new System.Windows.Forms.DataGridViewButtonColumn();
-            this.FactoriesPrioListColumnName = new System.Windows.Forms.DataGridViewComboBoxColumn();
-            this.FactoriesPrioListColumnWant = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.flowLayoutPanel1.SuspendLayout();
             this.tabControl1.SuspendLayout();
             this.tabPage1.SuspendLayout();
             this.tabPage2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.FactoryPriorityMaterialsDataGridView)).BeginInit();
             this.tabPage3.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.GlobalBlueprintTriggersDataGridView)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.GlobalBluePrintsDataView)).BeginInit();
             this.SuspendLayout();
             // 
@@ -342,6 +346,28 @@
             this.FactoryPriorityMaterialsDataGridView.Size = new System.Drawing.Size(838, 243);
             this.FactoryPriorityMaterialsDataGridView.TabIndex = 21;
             // 
+            // FactoriesPrioListColumnName
+            // 
+            this.FactoriesPrioListColumnName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.FactoriesPrioListColumnName.DataPropertyName = "Type";
+            this.FactoriesPrioListColumnName.HeaderText = "Material";
+            this.FactoriesPrioListColumnName.MinimumWidth = 80;
+            this.FactoriesPrioListColumnName.Name = "FactoriesPrioListColumnName";
+            this.FactoriesPrioListColumnName.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            // 
+            // FactoriesPrioListColumnWant
+            // 
+            this.FactoriesPrioListColumnWant.DataPropertyName = "Want";
+            dataGridViewCellStyle1.Format = "N0";
+            dataGridViewCellStyle1.NullValue = null;
+            this.FactoriesPrioListColumnWant.DefaultCellStyle = dataGridViewCellStyle1;
+            this.FactoriesPrioListColumnWant.HeaderText = "Number want";
+            this.FactoriesPrioListColumnWant.MinimumWidth = 8;
+            this.FactoriesPrioListColumnWant.Name = "FactoriesPrioListColumnWant";
+            this.FactoriesPrioListColumnWant.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+            this.FactoriesPrioListColumnWant.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
+            this.FactoriesPrioListColumnWant.Width = 200;
+            // 
             // FactoryPriorityItemsLabelMain
             // 
             this.FactoryPriorityItemsLabelMain.AutoSize = true;
@@ -390,7 +416,7 @@
             // 
             // tabPage3
             // 
-            this.tabPage3.Controls.Add(this.button2);
+            this.tabPage3.Controls.Add(this.GlobalBlueprintTriggersDataGridView);
             this.tabPage3.Controls.Add(this.label2);
             this.tabPage3.Controls.Add(this.GlobalBluePrintsDataView);
             this.tabPage3.Location = new System.Drawing.Point(4, 29);
@@ -400,16 +426,44 @@
             this.tabPage3.Text = "Global Blueprints";
             this.tabPage3.UseVisualStyleBackColor = true;
             // 
-            // button2
+            // GlobalBlueprintTriggersDataGridView
             // 
-            this.button2.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.button2.Location = new System.Drawing.Point(760, 339);
-            this.button2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
-            this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(114, 31);
-            this.button2.TabIndex = 14;
-            this.button2.Text = "Save";
-            this.button2.UseVisualStyleBackColor = true;
+            this.GlobalBlueprintTriggersDataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.GlobalBlueprintTriggersDataGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+            this.triggerBlueprintName,
+            this.triggerBuildingType,
+            this.triggerCount});
+            this.GlobalBlueprintTriggersDataGridView.Location = new System.Drawing.Point(17, 320);
+            this.GlobalBlueprintTriggersDataGridView.Name = "GlobalBlueprintTriggersDataGridView";
+            this.GlobalBlueprintTriggersDataGridView.RowHeadersWidth = 62;
+            this.GlobalBlueprintTriggersDataGridView.RowTemplate.Height = 28;
+            this.GlobalBlueprintTriggersDataGridView.Size = new System.Drawing.Size(857, 177);
+            this.GlobalBlueprintTriggersDataGridView.TabIndex = 2;
+            this.GlobalBlueprintTriggersDataGridView.RowEnter += new System.Windows.Forms.DataGridViewCellEventHandler(this.GlobalBlueprintTriggersDataGridView_RowEnter);
+            this.GlobalBlueprintTriggersDataGridView.RowsAdded += new System.Windows.Forms.DataGridViewRowsAddedEventHandler(this.GlobalBlueprintTriggersDataGridView_RowsAdded);
+            // 
+            // triggerBlueprintName
+            // 
+            this.triggerBlueprintName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.triggerBlueprintName.HeaderText = "Blueprint Name";
+            this.triggerBlueprintName.MinimumWidth = 8;
+            this.triggerBlueprintName.Name = "triggerBlueprintName";
+            // 
+            // triggerBuildingType
+            // 
+            this.triggerBuildingType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.triggerBuildingType.DataPropertyName = "BuildingType";
+            this.triggerBuildingType.HeaderText = "Building Type";
+            this.triggerBuildingType.MinimumWidth = 8;
+            this.triggerBuildingType.Name = "triggerBuildingType";
+            // 
+            // triggerCount
+            // 
+            this.triggerCount.DataPropertyName = "MaterialCount";
+            this.triggerCount.HeaderText = "Count";
+            this.triggerCount.MinimumWidth = 8;
+            this.triggerCount.Name = "triggerCount";
+            this.triggerCount.Width = 150;
             // 
             // label2
             // 
@@ -431,7 +485,7 @@
             this.GlobalBluePrintsDataView.Name = "GlobalBluePrintsDataView";
             this.GlobalBluePrintsDataView.RowHeadersWidth = 62;
             this.GlobalBluePrintsDataView.RowTemplate.Height = 28;
-            this.GlobalBluePrintsDataView.Size = new System.Drawing.Size(857, 286);
+            this.GlobalBluePrintsDataView.Size = new System.Drawing.Size(857, 246);
             this.GlobalBluePrintsDataView.TabIndex = 0;
             this.GlobalBluePrintsDataView.CellContentClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.GlobalBluePrintsDataView_CellContentClick);
             this.GlobalBluePrintsDataView.RowValidating += new System.Windows.Forms.DataGridViewCellCancelEventHandler(this.GlobalBluePrintsDataView_RowValidating);
@@ -465,28 +519,6 @@
             this.blueprintLoad.UseColumnTextForButtonValue = true;
             this.blueprintLoad.Width = 150;
             // 
-            // FactoriesPrioListColumnName
-            // 
-            this.FactoriesPrioListColumnName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
-            this.FactoriesPrioListColumnName.DataPropertyName = "Type";
-            this.FactoriesPrioListColumnName.HeaderText = "Material";
-            this.FactoriesPrioListColumnName.MinimumWidth = 80;
-            this.FactoriesPrioListColumnName.Name = "FactoriesPrioListColumnName";
-            this.FactoriesPrioListColumnName.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            // 
-            // FactoriesPrioListColumnWant
-            // 
-            this.FactoriesPrioListColumnWant.DataPropertyName = "Want";
-            dataGridViewCellStyle1.Format = "N0";
-            dataGridViewCellStyle1.NullValue = null;
-            this.FactoriesPrioListColumnWant.DefaultCellStyle = dataGridViewCellStyle1;
-            this.FactoriesPrioListColumnWant.HeaderText = "Number want";
-            this.FactoriesPrioListColumnWant.MinimumWidth = 8;
-            this.FactoriesPrioListColumnWant.Name = "FactoriesPrioListColumnWant";
-            this.FactoriesPrioListColumnWant.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.FactoriesPrioListColumnWant.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.NotSortable;
-            this.FactoriesPrioListColumnWant.Width = 200;
-            // 
             // SettingsForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
@@ -506,6 +538,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.FactoryPriorityMaterialsDataGridView)).EndInit();
             this.tabPage3.ResumeLayout(false);
             this.tabPage3.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.GlobalBlueprintTriggersDataGridView)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.GlobalBluePrintsDataView)).EndInit();
             this.ResumeLayout(false);
 
@@ -540,11 +573,14 @@
         private System.Windows.Forms.TabPage tabPage3;
         private System.Windows.Forms.DataGridView GlobalBluePrintsDataView;
         private System.Windows.Forms.Label label2;
-        private System.Windows.Forms.Button button2;
         private System.Windows.Forms.DataGridViewTextBoxColumn blueprintName;
         private System.Windows.Forms.DataGridViewButtonColumn blueprintSave;
         private System.Windows.Forms.DataGridViewButtonColumn blueprintLoad;
         private System.Windows.Forms.DataGridViewComboBoxColumn FactoriesPrioListColumnName;
         private System.Windows.Forms.DataGridViewTextBoxColumn FactoriesPrioListColumnWant;
+        private System.Windows.Forms.DataGridView GlobalBlueprintTriggersDataGridView;
+        private System.Windows.Forms.DataGridViewComboBoxColumn triggerBlueprintName;
+        private System.Windows.Forms.DataGridViewComboBoxColumn triggerBuildingType;
+        private System.Windows.Forms.DataGridViewTextBoxColumn triggerCount;
     }
 }

--- a/SettingsForm.cs
+++ b/SettingsForm.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading;
@@ -9,6 +10,8 @@ namespace NGUIndustriesInjector
 {
     public partial class SettingsForm : Form
     {
+        //private BindingList<string> globalBluePrintNames = new BindingList<string>();
+        private List<string> globalBluePrintNames;
         private bool _initializing = true;
 
         public SettingsForm()
@@ -42,6 +45,10 @@ namespace NGUIndustriesInjector
 
             FactoryPriorityMaterialsDataGridView.DataSource = new BindingSource(new BindingList<PriorityMaterial>(Main.Settings.PriorityBuildings), null);
             GlobalBluePrintsDataView.DataSource = new BindingSource(new BindingList<GlobalBlueprint>(Main.Settings.GlobalBlueprints), null);
+            // globalBluePrintNames = new BindingList<string>((IList<string>)Main.Settings.GlobalBlueprints?.Select(blueprint => blueprint.Name));
+            //globalBluePrintNames = new BindingSource(new BindingList<string>(Main.Settings.GlobalBlueprints?.Select(blueprint => blueprint.Name).ToList()), null);
+            globalBluePrintNames = new List<string>(Main.Settings.GlobalBlueprints?.Select(blueprint => blueprint.Name));
+            GlobalBlueprintTriggersDataGridView.DataSource = new BindingSource(new BindingList<GlobalBlueprintTrigger>(Main.Settings.GlobalBlueprintTriggers), null);
 
             Refresh();
             _initializing = false;
@@ -213,6 +220,28 @@ namespace NGUIndustriesInjector
                 e.Cancel = true;
                 return;
             }
+        }
+
+        private void GlobalBlueprintTriggersDataGridView_RowsAdded(object sender, DataGridViewRowsAddedEventArgs e)
+        {
+            Main.Debug("Hit GlobalBlueprintTriggersDataGridView_RowsAdded", "GlobalBlueprintTriggersDataGridView_RowsAdded");
+            DataGridViewComboBoxCell box = GlobalBlueprintTriggersDataGridView.Rows[e.RowIndex].Cells[0] as DataGridViewComboBoxCell;
+            
+            box.Items.Clear();
+            box.Items.AddRange(globalBluePrintNames);
+            // box.DataSource = globalBluePrintNames;
+        }
+
+        private void GlobalBlueprintTriggersDataGridView_RowEnter(object sender, DataGridViewCellEventArgs e)
+        {
+
+            Main.Debug("Hit GlobalBlueprintTriggersDataGridView_RowEnter", "GlobalBlueprintTriggersDataGridView_RowEnter");
+            DataGridViewComboBoxCell box = GlobalBlueprintTriggersDataGridView.Rows[e.RowIndex].Cells[0] as DataGridViewComboBoxCell;
+
+            box.Items.Clear();
+            box.Items.AddRange(globalBluePrintNames);
+
+            GlobalBlueprintTriggersDataGridView.Rows[e.RowIndex].Cells[0] = box;
         }
     }
 }

--- a/SettingsForm.resx
+++ b/SettingsForm.resx
@@ -117,16 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="FactoriesPrioListColumnName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="TriggerListBlueprintColumnName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <metadata name="FactoriesPrioListColumnWant.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="triggerBlueprintName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="triggerBuildingType.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+  <metadata name="TriggerBlueprintBuildingTypeColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="triggerCount.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
@@ -139,6 +133,18 @@
     <value>True</value>
   </metadata>
   <metadata name="blueprintLoad.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="FactoriesPrioListColumnName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="FactoriesPrioListColumnWant.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="FactoriesPrioListColumnName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="FactoriesPrioListColumnWant.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
 </root>

--- a/SettingsForm.resx
+++ b/SettingsForm.resx
@@ -123,6 +123,15 @@
   <metadata name="FactoriesPrioListColumnWant.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="triggerBlueprintName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="triggerBuildingType.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="triggerCount.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="blueprintName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>


### PR DESCRIPTION
**Add Global Blueprint Triggers**

![image](https://user-images.githubusercontent.com/6985091/125328708-9eea3e00-e312-11eb-808d-fca97f656193.png)

You set a trigger by identifying a Global Blueprint you want to swap to, a material and a count and then clicking save. Only the **TOP** trigger is looked at every .5 seconds. Once you have reached the specific number of the specified resource you will automatically be swapped to the specified blueprint and the activated trigger will be removed from the list. You can have multiple triggers that are processed in order this way. 

Known issues:
- Sometimes deleting rows can lead to exceptions and I haven't been able to figure out why
- The **Blueprint Name** and **Building Type** columns have their selected text cut-off. I have not been able to find a solution to this problem
- On occasion the **Blueprint Name** drop-down de-syncs with the names of Global Blueprints. Triggering a save by clicking the Save button seems to fix this